### PR TITLE
Handle missing respository in GitRef

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 ## Developing
 
-Get your access token [from GitHub](https://github.com/settings/tokens)
+Get your access token [from GitHub](https://github.com/settings/tokens) with a `public_repo` scope.
 
 Start the server:
 
     $ sbt
-    > ~reStart run --- -Dakka.minion.access-token=<github_access_token> -Dakka.minion.poll-interval=10h
+    > ~reStart run --- -Dakka.minion.poll-interval=10h -Dakka.minion.access-token=<github_access_token>
 
 This will start the app and configure it to not poll GitHub after the initial poll. This will save API quota while developing the application. To stop it run:
 


### PR DESCRIPTION
Can happen when PR head repository gets removed,
like in https://github.com/lightbend/config/pull/373