### PR TITLE
Use the new Github Graphql API to get issue stats

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,2 @@
 language: scala
+scala: 2.13.1

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 organization := "akka"
 name := "akka-minion"
 
-scalaVersion := "2.12.9"
+scalaVersion := "2.13.1"
 scalacOptions ++= List(
   "-unchecked",
   "-deprecation",

--- a/src/main/resources/.gitignore
+++ b/src/main/resources/.gitignore
@@ -1,0 +1,1 @@
+github-token.conf

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,16 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%-20.20thread] %-36.36logger{36}  %msg%n%rEx</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="akka" level="warn" />
+    <logger name="akka.http" level="warn" />
+    <logger name="akka.minion" level="debug" />
+    <logger name="com.typesafe" level="warn" />
+
+    <root level="debug">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -77,3 +77,4 @@ akka.minion {
     }
   ]
 }
+include "github-token.conf"

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -76,5 +76,19 @@ akka.minion {
       ]
     }
   ]
+
+  stats-repos = [
+    "akka/akka",
+    "akka/akka-management",
+    "akka/akka-persistence-cassandra",
+    "akka/akka-persistence-couchbase",
+    "akka/akka-persistence-jdbc",
+    "akka/akka-grpc",
+    "akka/akka-http",
+    "akka/alpakka",
+    "akka/alpakka-kafka",
+    "lagom/lagom",
+    "playframework/playframework",
+  ]
 }
 include "github-token.conf"

--- a/src/main/scala/akka/minion/App.scala
+++ b/src/main/scala/akka/minion/App.scala
@@ -5,14 +5,11 @@ import java.util.concurrent.TimeUnit
 import akka.ConfigurationException
 import akka.actor.SupervisorStrategy.{Restart, Stop}
 import akka.actor.{Actor, ActorSystem, OneForOneStrategy, Props, SupervisorStrategy}
-import com.typesafe.config.ConfigList
 
-import scala.io.StdIn
-import scala.util.control.NonFatal
-import scala.concurrent.duration._
-import scala.collection.immutable.Seq
 import scala.concurrent.Await
-import scala.collection.JavaConverters._
+import scala.concurrent.duration._
+import scala.jdk.CollectionConverters._
+import scala.util.control.NonFatal
 
 object App {
   case object ServicePing

--- a/src/main/scala/akka/minion/GithubCaller.scala
+++ b/src/main/scala/akka/minion/GithubCaller.scala
@@ -18,12 +18,12 @@ import scala.concurrent.duration._
 trait GithubCaller {
 
   implicit def system: ActorSystem
-  implicit val ec: ExecutionContext = system.dispatcher
+  implicit lazy val ec: ExecutionContext = system.dispatcher
   def GitHubUrl: String
   def settings: Settings
 
   // Throttled global connection pool
-  val (queue: SourceQueueWithComplete[(HttpRequest, Promise[HttpResponse])], clientFuture: Future[Done]) =
+  lazy val (queue: SourceQueueWithComplete[(HttpRequest, Promise[HttpResponse])], clientFuture: Future[Done]) =
     Source
       .queue[(HttpRequest, Promise[HttpResponse])](512, OverflowStrategy.backpressure)
       .throttle(settings.apiCallPerHour, 1.hour, 300, ThrottleMode.shaping)

--- a/src/main/scala/akka/minion/GithubCaller.scala
+++ b/src/main/scala/akka/minion/GithubCaller.scala
@@ -1,0 +1,93 @@
+package akka.minion
+
+import akka.Done
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.HttpMethods.GET
+import akka.http.scaladsl.model.{headers, HttpRequest, HttpResponse, MediaRange, ResponseEntity, StatusCodes, Uri}
+import akka.http.scaladsl.unmarshalling.{Unmarshal, Unmarshaller}
+import akka.minion.App.Settings
+import akka.stream.{OverflowStrategy, ThrottleMode}
+import akka.stream.scaladsl.{Keep, Sink, Source, SourceQueueWithComplete}
+import com.github.blemale.scaffeine.Scaffeine
+import spray.json.RootJsonFormat
+
+import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.concurrent.duration._
+
+trait GithubCaller {
+
+  implicit def system: ActorSystem
+  implicit val ec: ExecutionContext = system.dispatcher
+  def GitHubUrl: String
+  def settings: Settings
+
+  // Throttled global connection pool
+  val (queue: SourceQueueWithComplete[(HttpRequest, Promise[HttpResponse])], clientFuture: Future[Done]) =
+    Source
+      .queue[(HttpRequest, Promise[HttpResponse])](512, OverflowStrategy.backpressure)
+      .throttle(settings.apiCallPerHour, 1.hour, 300, ThrottleMode.shaping)
+      .via(Http(system).cachedHostConnectionPoolHttps(GitHubUrl))
+      .toMat(Sink.foreach {
+        case (response, promise) =>
+          promise.tryComplete(response)
+      })(Keep.both)
+      .run()
+
+  private val responseCache = Scaffeine()
+    .maximumSize(500)
+    .build[Uri, (headers.EntityTag, Any)]()
+
+  protected def throttledRequest(req: HttpRequest): Future[HttpResponse] = {
+    val promise = Promise[HttpResponse]
+
+    val request = req
+      .addHeader(headers.Authorization(headers.GenericHttpCredentials("token", settings.token)))
+      .addHeader(headers.Accept(MediaRange.custom("application/vnd.github.black-cat-preview+json")))
+
+    queue.offer(request -> promise).flatMap(_ => promise.future)
+  }
+  private def throttledJson[T: RootJsonFormat](
+      req: HttpRequest
+  )(implicit um: Unmarshaller[ResponseEntity, T]): Future[T] = {
+    val etag = responseCache.getIfPresent(req.uri)
+    throttledRequest(etag.fold(req) {
+      case (tag, _) => req.addHeader(headers.`If-None-Match`(tag))
+    }).flatMap {
+      case response @ HttpResponse(StatusCodes.NotModified, _, _, _) =>
+        response.discardEntityBytes()
+        etag match {
+          case Some((_, res)) => Future.successful(res.asInstanceOf[T])
+          case None =>
+            throw new Error("No changes from the cached version, but cache is empty.")
+        }
+      case response @ HttpResponse(StatusCodes.OK, _, entity, _) =>
+        val resp = Unmarshal(entity).to[T]
+        resp.foreach {
+          case r =>
+            response
+              .header[headers.ETag]
+              .fold(())(e => responseCache.put(req.uri, (e.etag, r)))
+        }
+        resp.transform(
+          identity,
+          ex => new Error(s"Failure while deserializing response from $GitHubUrl${req.uri}", ex)
+        )
+      case response =>
+        Future.failed(
+          new Error(
+            s"Request to github service [${req.uri}] failed: got status code [${response.status}] and body [${Unmarshal(response.entity)
+              .to[String]}]"
+          )
+        )
+    }
+  }
+
+  protected def api[T: RootJsonFormat](repo: String, apiPath: String = "", base: String = "/repos/")(
+      implicit um: Unmarshaller[ResponseEntity, T]
+  ): Future[T] = {
+    val req = HttpRequest(GET, uri = s"$base$repo$apiPath")
+    throttledJson[T](req)
+  }
+
+}

--- a/src/main/scala/akka/minion/Graphql.scala
+++ b/src/main/scala/akka/minion/Graphql.scala
@@ -1,0 +1,127 @@
+package akka.minion
+
+import akka.actor.ActorSystem
+import akka.minion.App.Settings
+import spray.json.{DefaultJsonProtocol, RootJsonFormat}
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+object Graphql extends DefaultJsonProtocol {
+  case class Owner(login: String)
+  case class Total(totalCount: Int) {
+    def pretty = f"$totalCount%6d"
+  }
+  case class StatsDataRepo(
+      owner: Owner,
+      name: String,
+      issuesTotal: Total,
+      issuesOpen: Total,
+      issuesFailed: Total,
+      prTotal: Total,
+      prOpen: Total
+  ) {
+    def pretty() =
+      s""" ${owner.login}/$name
+         | Total issues   ${issuesTotal.pretty}
+         | Open issues    ${issuesOpen.pretty}
+         | Open failures  ${issuesFailed.pretty}
+         |
+         | Total PRs      ${prTotal.pretty}
+         | Open PRs       ${prOpen.pretty}
+         |""".stripMargin
+
+    def markdown() =
+      s"""||${owner.login}/$name | |
+          ||--------------|--|
+          ||Total issues  | ${issuesTotal.pretty} |
+          ||Open issues   | ${issuesOpen.pretty} |
+          ||Open failures | ${issuesFailed.pretty} |
+          ||Total PRs     | ${prTotal.pretty} |
+          ||Open PRs      | ${prOpen.pretty} |
+          |""".stripMargin
+  }
+  case class StatsData(repo: StatsDataRepo)
+  case class Stats(data: StatsData)
+
+  private type RJF[x] = RootJsonFormat[x]
+
+  implicit lazy val _fmtOwner: RJF[Owner] = jsonFormat1(Owner)
+  implicit lazy val _fmtTotal: RJF[Total] = jsonFormat1(Total)
+  implicit lazy val _fmtStatsDataRepo: RJF[StatsDataRepo] = jsonFormat7(StatsDataRepo)
+  implicit lazy val _fmtStatsData: RJF[StatsData] = jsonFormat1(StatsData)
+  implicit lazy val _fmtStats: RJF[Stats] = jsonFormat1(Stats)
+
+}
+
+class Graphql(val settings: Settings)(implicit val system: ActorSystem) extends GithubCaller {
+
+  import Graphql._
+
+  final val GitHubUrl = "api.github.com"
+
+  def statsQuery(repoOwner: String, repoName: String) =
+    s"""query {
+      |  repo: repository(name: "$repoName", owner: "$repoOwner") {
+      |    owner {login}
+      |    name
+      |    issuesTotal: issues {
+      |      totalCount
+      |    }
+      |    issuesOpen: issues(states: OPEN) {
+      |      totalCount
+      |    }
+      |    issuesFailed: issues(states: OPEN, labels: "failed") {
+      |      totalCount
+      |    }
+      |    prTotal: pullRequests {
+      |      totalCount
+      |    }
+      |    prOpen: pullRequests(states: OPEN) {
+      |      totalCount
+      |    }
+      |  }
+      |}
+      |""".stripMargin
+
+  val statsReply =
+    """{
+      |  "data": {
+      |    "repo": {
+      |      "owner": {
+      |        "login": "akka"
+      |      },
+      |      "name": "akka",
+      |      "issues_total": {
+      |        "totalCount": 6810
+      |      },
+      |      "issues_open": {
+      |        "totalCount": 819
+      |      },
+      |      "issues_failed": {
+      |        "totalCount": 41
+      |      },
+      |      "pr_total": {
+      |        "totalCount": 9476
+      |      },
+      |      "pr_open": {
+      |        "totalCount": 55
+      |      },
+      |
+      |
+      |""".stripMargin
+
+  def call() = {
+    val allRepos = settings.teamRepos.values.fold(Set.empty)(_ ++ _).toList.sorted
+    for {
+      r <- allRepos
+      Array(owner, name) = r.split('/')
+    } {
+      val repoFuture = graphql[Stats](statsQuery(owner, name))
+      println(Await.result(repoFuture, 10.seconds).data.repo.markdown())
+      println()
+    }
+  }
+
+}

--- a/src/main/scala/akka/minion/Graphql.scala
+++ b/src/main/scala/akka/minion/Graphql.scala
@@ -1,5 +1,9 @@
 package akka.minion
 
+import java.text.DateFormat
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
 import akka.actor.ActorSystem
 import akka.minion.App.Settings
 import spray.json.{DefaultJsonProtocol, RootJsonFormat}
@@ -9,6 +13,8 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 
 object Graphql extends DefaultJsonProtocol {
+  private val tab = 9.toChar
+
   case class Owner(login: String)
   case class Total(totalCount: Int) {
     def pretty = f"$totalCount%6d"
@@ -18,7 +24,10 @@ object Graphql extends DefaultJsonProtocol {
       name: String,
       issuesTotal: Total,
       issuesOpen: Total,
-      issuesFailed: Total,
+      issuesBugTotal: Total,
+      issuesBugOpen: Total,
+      issuesFailedTotal: Total,
+      issuesFailedOpen: Total,
       prTotal: Total,
       prOpen: Total
   ) {
@@ -26,7 +35,10 @@ object Graphql extends DefaultJsonProtocol {
       s""" ${owner.login}/$name
          | Total issues   ${issuesTotal.pretty}
          | Open issues    ${issuesOpen.pretty}
-         | Open failures  ${issuesFailed.pretty}
+         | Total bugs     ${issuesBugTotal.pretty}
+         | Open bugs      ${issuesBugOpen.pretty}
+         | Total failures ${issuesFailedTotal.pretty}
+         | Open failures  ${issuesFailedOpen.pretty}
          |
          | Total PRs      ${prTotal.pretty}
          | Open PRs       ${prOpen.pretty}
@@ -34,13 +46,27 @@ object Graphql extends DefaultJsonProtocol {
 
     def markdown() =
       s"""||${owner.login}/$name | |
-          ||--------------|--|
-          ||Total issues  | ${issuesTotal.pretty} |
-          ||Open issues   | ${issuesOpen.pretty} |
-          ||Open failures | ${issuesFailed.pretty} |
-          ||Total PRs     | ${prTotal.pretty} |
-          ||Open PRs      | ${prOpen.pretty} |
+          ||---------------|--|
+          ||Total issues   | ${issuesTotal.pretty} |
+          ||Open issues    | ${issuesOpen.pretty} |
+          ||Total bugs     | ${issuesBugTotal.pretty} |
+          ||Open bugs      | ${issuesBugOpen.pretty} |
+          ||Total failures | ${issuesFailedTotal.pretty} |
+          ||Open failures  | ${issuesFailedOpen.pretty} |
+          ||Total PRs      | ${prTotal.pretty} |
+          ||Open PRs       | ${prOpen.pretty} |
           |""".stripMargin
+
+    def spreadsheet() =
+      s"${DateTimeFormatter.ISO_DATE.format(LocalDate.now())}$tab " +
+      s"${issuesTotal.totalCount - issuesOpen.totalCount}$tab " +
+      s"${issuesOpen.totalCount}$tab " +
+      s"${issuesBugTotal.totalCount - issuesBugOpen.totalCount}$tab " +
+      s"${issuesBugOpen.totalCount}$tab " +
+      s"${issuesFailedTotal.totalCount - issuesFailedOpen.totalCount}$tab " +
+      s"${issuesFailedOpen.totalCount}$tab " +
+      s"${prTotal.totalCount}$tab " +
+      s"${prOpen.totalCount}$tab "
   }
   case class StatsData(repo: StatsDataRepo)
   case class Stats(data: StatsData)
@@ -49,7 +75,7 @@ object Graphql extends DefaultJsonProtocol {
 
   implicit lazy val _fmtOwner: RJF[Owner] = jsonFormat1(Owner)
   implicit lazy val _fmtTotal: RJF[Total] = jsonFormat1(Total)
-  implicit lazy val _fmtStatsDataRepo: RJF[StatsDataRepo] = jsonFormat7(StatsDataRepo)
+  implicit lazy val _fmtStatsDataRepo: RJF[StatsDataRepo] = jsonFormat10(StatsDataRepo)
   implicit lazy val _fmtStatsData: RJF[StatsData] = jsonFormat1(StatsData)
   implicit lazy val _fmtStats: RJF[Stats] = jsonFormat1(Stats)
 
@@ -72,7 +98,16 @@ class Graphql(val settings: Settings)(implicit val system: ActorSystem) extends 
       |    issuesOpen: issues(states: OPEN) {
       |      totalCount
       |    }
-      |    issuesFailed: issues(states: OPEN, labels: "failed") {
+      |    issuesBugTotal: issues(labels: "bug") {
+      |      totalCount
+      |    }
+      |    issuesBugOpen: issues(states: OPEN, labels: "bug") {
+      |      totalCount
+      |    }
+      |    issuesFailedTotal: issues(labels: "failed") {
+      |      totalCount
+      |    }
+      |    issuesFailedOpen: issues(states: OPEN, labels: "failed") {
       |      totalCount
       |    }
       |    prTotal: pullRequests {
@@ -113,15 +148,21 @@ class Graphql(val settings: Settings)(implicit val system: ActorSystem) extends 
       |""".stripMargin
 
   def call() = {
-    val allRepos = settings.teamRepos.values.fold(Set.empty)(_ ++ _).toList.sorted
+    val header = new StringBuilder
+    val data = new StringBuilder()
     for {
-      r <- allRepos
+      r <- settings.statsRepos
       Array(owner, name) = r.split('/')
     } {
       val repoFuture = graphql[Stats](statsQuery(owner, name))
-      println(Await.result(repoFuture, 10.seconds).data.repo.markdown())
-      println()
+      val stats = Await.result(repoFuture, 10.seconds)
+      header.append(
+        s"$r$tab Issues Total$tab Open issues$tab Bugs Closed$tab Bugs Open$tab Failures Closed$tab Failures Open$tab PR Total$tab PR Open$tab "
+      )
+      data.append(stats.data.repo.spreadsheet())
     }
+    println(header.toString())
+    println(data.toString())
   }
 
 }

--- a/src/main/scala/akka/minion/HttpServer.scala
+++ b/src/main/scala/akka/minion/HttpServer.scala
@@ -7,7 +7,7 @@ import akka.http.scaladsl.server.Directives._
 import akka.minion.App.Settings
 import akka.minion.Dashboard._
 import akka.pattern.{ask, AskTimeoutException}
-import akka.stream.ActorMaterializer
+import akka.stream.{Materializer, SystemMaterializer}
 import akka.util.Timeout
 
 import scala.concurrent.Future
@@ -29,7 +29,7 @@ class HttpServer(
     with ActorLogging {
   import context.dispatcher
 
-  private implicit val materializer = ActorMaterializer()
+  private implicit val materializer: Materializer = SystemMaterializer(context.system).materializer
   private var bindingFuture: Future[Http.ServerBinding] = _
 
   implicit val timeout = Timeout(3.seconds)
@@ -48,7 +48,7 @@ class HttpServer(
       redirect("/", StatusCodes.PermanentRedirect)
     } ~
     pathSingleSlash {
-      parameters('team ?) { team =>
+      parameters(Symbol("team") ?) { team =>
         get {
           val reportFuture =
             (dashboard ? GetMainDashboard)


### PR DESCRIPTION
The Github API v4 is based on Graphql and allows to read data more dynamically and the old REST API.
This adds a (not really built-in) feature to use Graphql to read stats about open issues and PRs across all our repos.